### PR TITLE
added .env file, and ignored the fake certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 serviceAccountKey.json
 oauthKey.js
 keys.js
+cert.pem
+key.pem
 
 # dependencies
 node_modules/

--- a/src/frontend/.env
+++ b/src/frontend/.env
@@ -1,0 +1,3 @@
+HTTPS=true
+SSL_CRT_FILE=./../backend/config/cert.pem
+SSL_KEY_FILE=./../backend/config/key.pem


### PR DESCRIPTION
Hey,

Since we got `https` working I figure we should emulate `https` in our dev environments so I went ahead and created a `.env` file which specifies that we're using https, and I generated a cert and key that we can all share. I'll send that privately.